### PR TITLE
Use tempdir and copy result to pwd

### DIFF
--- a/pacwall.sh
+++ b/pacwall.sh
@@ -10,66 +10,104 @@ NODE='#dc143c88'
 ENODE=darkorange
 EDGE='#ffffff44'
 
-echo 'Generating the graph.'
+STARTDIR="${PWD}"
+
+OUTPUT="pacwall.png"
+
+WORKDIR=""
 
 # Prepare the environment.
-mkdir -p /tmp/pacwall
-cd /tmp/pacwall
-mkdir -p stripped
-mkdir -p raw
-cat /dev/null > /tmp/pkgcolors
+prepare() {
+    WORKDIR="$(mktemp -d)"
+    mkdir -p "${WORKDIR}/"{stripped,raw}
+    touch "${WORKDIR}/pkgcolors"
+}
 
-# Get a space-separated list of the explicitly installed packages.
-epkgs="$(pacman -Qeq | tr '\n' ' ')"
-for package in $epkgs
-do
+cleanup() {
+    cd "${STARTDIR}" && rm -rf "${WORKDIR}"
+}
 
-    # Mark each explicitly installed package using a distinct solid color.
-    echo "\"$package\" [color=$ENODE]" >> pkgcolors
+generate_graph() {
+    # Get a space-separated list of the explicitly installed packages.
+    epkgs="$(pacman -Qeq | tr '\n' ' ')"
+    for package in ${epkgs}
+    do
 
-    # Extract the list of edges from the output of pactree.
-    pactree -g "$package" > "raw/$package"
-    sed -E \
-        -e '/START/d' \
-        -e '/^node/d' \
-        -e '/\}/d' \
-        -e '/arrowhead=none/d' \
-        -e 's/\[.*\]//' \
-        -e 's/>?=.*" ->/"->/' \
-        -e 's/>?=.*"/"/' \
-        "raw/$package" > "stripped/$package"
+        # Mark each explicitly installed package using a distinct solid color.
+        echo "\"$package\" [color=$ENODE]" >> pkgcolors
 
-done
+        # Extract the list of edges from the output of pactree.
+        pactree -g "$package" > "raw/$package"
+        sed -E \
+            -e '/START/d' \
+            -e '/^node/d' \
+            -e '/\}/d' \
+            -e '/arrowhead=none/d' \
+            -e 's/\[.*\]//' \
+            -e 's/>?=.*" ->/"->/' \
+            -e 's/>?=.*"/"/' \
+            "raw/$package" > "stripped/$package"
 
-# Compile the file in DOT languge.
-# The graph is directed and strict (doesn't contain any edge duplicates).
-cd stripped
-echo 'strict digraph G {' > ../pacwall.gv
-cat ../pkgcolors $epkgs >> ../pacwall.gv
-echo '}' >> ../pacwall.gv
+    done
+}
 
-# Style the graph according to preferences.
-echo 'Rendering it.'
-cd ..
-twopi \
-    -Tpng pacwall.gv \
-    -Gbgcolor=$BACKGROUND \
-    -Ecolor=$EDGE\
-    -Ncolor=$NODE \
-    -Nshape=point \
-    -Nheight=0.1 \
-    -Nwidth=0.1 \
-    -Earrowhead=normal \
-    > pacwall.png
+compile_graph() {
+    # Compile the file in DOT languge.
+    # The graph is directed and strict (doesn't contain any edge duplicates).
+    cd stripped
+    echo 'strict digraph G {' > ../pacwall.gv
+    cat ../pkgcolors ${epkgs} >> ../pacwall.gv
+    echo '}' >> ../pacwall.gv
+}
 
-# Use imagemagick to resize the image to the size of the screen.
-echo 'Changing the wallpaper.'
-convert pacwall.png \
-    -gravity center \
-    -background $BACKGROUND \
-    -extent $SCREEN_SIZE \
-    pacwall.png
+render_graph() {
+    # Style the graph according to preferences.
+    cd ..
+    twopi \
+        -Tpng pacwall.gv \
+        -Gbgcolor="${BACKGROUND}" \
+        -Ecolor="${EDGE}" \
+        -Ncolor="${NODE}" \
+        -Nshape=point \
+        -Nheight=0.1 \
+        -Nwidth=0.1 \
+        -Earrowhead=normal \
+        > pacwall.png
+}
 
-feh --bg-center --no-fehbg pacwall.png
+resize_wallpaper() {
+    # Use imagemagick to resize the image to the size of the screen.
+    convert pacwall.png \
+        -gravity center \
+        -background "${BACKGROUND}" \
+        -extent "${SCREEN_SIZE}" \
+        pacwall.png
 
-echo 'Done.'
+    feh --bg-center --no-fehbg pacwall.png
+}
+
+main() {
+    prepare
+
+    cd "${WORKDIR}"
+
+    echo 'Generating the graph.'
+    generate_graph
+
+    echo 'Compiling the graph.'
+    compile_graph
+
+    echo 'Rendering it.'
+    render_graph
+
+    echo 'Resizing the wallpaper.'
+    resize_wallpaper
+
+    cp "${WORKDIR}/${OUTPUT}" "${STARTDIR}"
+
+    cleanup
+
+    echo 'Done.'
+}
+
+main


### PR DESCRIPTION
Rather than creating a directory that might already exist, especially if the script has been run once, use a temporary directory created by `mktemp`. At the end just copy the result to the `pwd`, and delete the temporary directory.

I also modularized the code a bit.