### PR TITLE
Fixed PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,1 @@
+PKGBUILD-git

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -11,6 +11,7 @@ optdepends=('feh: wallpaper setting using feh'
             'hsetroot: wallpaper setting using hsetroot'
             'imagemagick: wallpaper setting on GNOME'
             'xorg-xdpyinfo: auto-detection of screen size on GNOME (Xorg)')
+makedepends=('git')
 conflicts=("${_pkgname}")
 source=("${_pkgname}::git+https://github.com/Kharacternyk/${_pkgname}.git#branch=master")
 sha256sums=(SKIP)

--- a/PKGBUILD-git
+++ b/PKGBUILD-git
@@ -12,7 +12,7 @@ optdepends=('feh: wallpaper setting using feh'
             'imagemagick: wallpaper setting on GNOME'
             'xorg-xdpyinfo: auto-detection of screen size on GNOME (Xorg)')
 conflicts=("${_pkgname}")
-source=("${_pkgname}::git+https://github.com/Kharacternyk/${_pkgname}#branch=master")
+source=("${_pkgname}::git+https://github.com/Kharacternyk/${_pkgname}.git#branch=master")
 sha256sums=(SKIP)
 
 pkgver() {


### PR DESCRIPTION
Fixed the source URL (the URL previously did not have .git suffix);
added git as makedepend to support build under a chroot environment;
symlink PKGBUILD-git to PKGBUILD as the default installation file name. 