### PR TITLE
Center root node

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,8 @@ Customizations can be made on the command line, see the options with
             If OUTLINE value is bigger than 1, then OUTLINE-1 additional circles are drawn
             around the corresponding packages.
 
-            ROOT is the package that will be put in the center of the graph.
+            ROOT is the package that will be put in the center of the graph. If not
+            specified, a package will be chosen, and the graph may be slightly off center.
             RANKSEP is the distance in **inches** between the concentric circles.
             OUTPUT is the path where the generated image is put.
             SCREEN_SIZE makes sense to set only if -D is enabled and you're on Wayland.
@@ -191,6 +192,14 @@ Graph size
 If the graph is too large/small, use ``-r``.
 For example, ``-r 0.3`` means that the distance between the concentric circles
 of the graph will be 0.3 **inch**.
+
+~~~~~~~~~~~~~~~~~~~
+Centering the graph
+~~~~~~~~~~~~~~~~~~~
+If the ``-c ROOT`` option is not used to specify a pacage to put at the center of
+the graph, one will be chosen (see the ``twopi`` man page). In this case, the
+central node will likely be somewhat off center in the resulting image.
+Specifying a root package will fix this.
 
 ------------
 Contributors

--- a/pacwall.sh
+++ b/pacwall.sh
@@ -408,6 +408,8 @@ main() {
 
     render_graph
 
+    center_root
+
     cp "${WORKDIR}/pacwall.gv.png" "${OUTPUT}"
 
     if [[ -z $IMAGE_ONLY ]]; then

--- a/pacwall.sh
+++ b/pacwall.sh
@@ -290,7 +290,7 @@ use_xresources_colors() {
 render_graph() {
     # Style the graph according to preferences.
     declare -a twopi_args=(
-        '-Tpng' 'pacwall.gv'
+        '-O' '-Tpng' '-Tplain' 'pacwall.gv'
         "-Gbgcolor=${BACKGROUND}"
         "-Granksep=${RANKSEP}"
         "-Ecolor=${EDGE}"
@@ -304,7 +304,7 @@ render_graph() {
     # Optional arguments
     [[ -n $ROOT ]] && twopi_args+=("-Groot=${ROOT}")
 
-    twopi "${twopi_args[@]}" > pacwall.png
+    twopi "${twopi_args[@]}"
 }
 
 center_root() {
@@ -347,7 +347,7 @@ set_wallpaper() {
             #TODO: handle if neither exists
         fi
 
-        convert pacwall.png \
+        convert pacwall.gv.png \
             -gravity center \
             -background "${BACKGROUND}" \
             -extent "${SCREEN_SIZE}" \
@@ -408,7 +408,7 @@ main() {
 
     render_graph
 
-    cp "${WORKDIR}/pacwall.png" "${OUTPUT}"
+    cp "${WORKDIR}/pacwall.gv.png" "${OUTPUT}"
 
     if [[ -z $IMAGE_ONLY ]]; then
         set_wallpaper

--- a/pacwall.sh
+++ b/pacwall.sh
@@ -457,7 +457,8 @@ help() {
         If OUTLINE value is bigger than 1, then OUTLINE-1 additional circles are drawn
         around the corresponding packages.
 
-        ROOT is the package that will be put in the center of the graph.
+        ROOT is the package that will be put in the center of the graph. If not
+        specified, a package will be chosen, and the graph may be slightly off center.
         RANKSEP is the distance in **inches** between the concentric circles.
         OUTPUT is the path where the generated image is put.
         SCREEN_SIZE makes sense to set only if -D is enabled and you're on Wayland.

--- a/pacwall.sh
+++ b/pacwall.sh
@@ -307,6 +307,28 @@ render_graph() {
     twopi "${twopi_args[@]}" > pacwall.png
 }
 
+center_root() {
+    [[ -z $ROOT ]] && return 0
+    HEADLINE=($(head -n1 pacwall.gv.plain))
+    GPHW=${HEADLINE[2]}
+    GPHH=${HEADLINE[3]}
+    ROOTLINE=($(grep -E "node \"?$ROOT\"? " pacwall.gv.plain))
+    ROOTX=${ROOTLINE[2]}
+    ROOTY=${ROOTLINE[3]}
+    IMGW=$(convert pacwall.gv.png -print '%w\n' /dev/null)
+    IMGH=$(convert pacwall.gv.png -print '%h\n' /dev/null)
+    XOFFSET=$(bc <<< "scale=5; $IMGW*(2.0*$ROOTX/$GPHW-1.0)")
+    YOFFSET=$(bc <<< "scale=5; $IMGH*(2.0*$ROOTY/$GPHH-1.0)")
+    # Set -gravity string depending on absolute values of XOFFSET and YOFFSET
+    [[ $XOFFSET = -* ]] && GRAVX='west'  || GRAVX='east'
+    [[ $YOFFSET = -* ]] && GRAVY='south' || GRAVY='north'
+    convert pacwall.gv.png \
+        -background "$BACKGROUND" \
+        -gravity "$GRAVY$GRAVX" \
+        -splice ${XOFFSET#-}x${YOFFSET#-} \
+        pacwall.gv.png
+}
+
 set_wallpaper() {
     set +e
 


### PR DESCRIPTION
This pull request adds a function to center the root node of the graph more precisely. It only works if the `-c` option is used to specify the root node on the command line. If no root node is specified with `-c`, the behaviour is unchanged.

This fixes issue #26 but only when `-c` is used.

I did some partial testing using e.g `./pacwall.sh` and `./pacwall.sh -c linux`, and everything seems to work as expected, but I did not test anything involving `-D`, `-W`, or Void/Gentoo.