### PR TITLE
hsetroot: fix missing graph when hook run with display off

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ If you use KDE Plasma, run:
     mkdir -p ~/.config/pacwall
     cp /usr/share/pacwall/examples/hook/plasmash ~/.config/pacwall/pacwall.conf
 
-If you use Xorg sans GNOME/KDE, run: [*]_
+If you use Xorg sans GNOME/KDE, run:
 
 .. code-block:: bash
 
@@ -58,13 +58,12 @@ For some setups, e.g. XFCE, there are no example hooks. Furthermore, the example
 hooks can have bugs. You can verify that ``pacwall`` itself works fine by examining
 the image that it has generated at ``~/.cache/pacwall/pacwall.png``.
 
-..[*] If you use the standard ``hsetroot`` hook along with a ``systemd`` unit
-listed below, you may notice that the background image (the package graph)
-disappears if the unit triggers while your screen is turned off (typically due
-to DPMS timeout). This can be fixed by using the
-``/usr/share/pacwall/examples/hook/hsetroot-dpms`` hook instead. However, on
-multi-display systems, this may cause undesired stretching of the graph over
-multiple screens.
+If you use the standard ``hsetroot`` hook along with a ``systemd`` unit listed
+below, you may notice that the package graph disappears if the unit triggers
+while your screen is turned off (typically due to DPMS timeout). This can be
+fixed by using the ``/usr/share/pacwall/examples/hook/hsetroot-dpms`` hook
+instead of the plain ``hsetroot`` one. However, on multi-display systems, this
+may cause undesired stretching of the graph over multiple screens.
 
 -----
 Usage

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ If you use KDE Plasma, run:
     mkdir -p ~/.config/pacwall
     cp /usr/share/pacwall/examples/hook/plasmash ~/.config/pacwall/pacwall.conf
 
-If you use Xorg sans GNOME/KDE, run:
-    
+If you use Xorg sans GNOME/KDE, run: [*]_
+
 .. code-block:: bash
 
     sudo pacman -S --needed hsetroot
@@ -57,6 +57,14 @@ If you use Sway, run:
 For some setups, e.g. XFCE, there are no example hooks. Furthermore, the example
 hooks can have bugs. You can verify that ``pacwall`` itself works fine by examining
 the image that it has generated at ``~/.cache/pacwall/pacwall.png``.
+
+..[*] If you use the standard ``hsetroot`` hook along with a ``systemd`` unit
+listed below, you may notice that the background image (the package graph)
+disappears if the unit triggers while your screen is turned off (typically due
+to DPMS timeout). This can be fixed by using the
+``/usr/share/pacwall/examples/hook/hsetroot-dpms`` hook instead. However, on
+multi-display systems, this may cause undesired stretching of the graph over
+multiple screens.
 
 -----
 Usage

--- a/examples/hook/hsetroot-dpms
+++ b/examples/hook/hsetroot-dpms
@@ -1,0 +1,1 @@
+hook: "hsetroot -solid '#073642' -center '$W' -root > /dev/null"


### PR DESCRIPTION
This PR adds a second `hsetroot`-based hook, which uses the `-root` flag to
ensure the background image is set even when the display is powered off (usually
due to DPMS).

Since this hook may cause issues on multi-display setups, it does not replace
the existing `hsetroot` hook, and a note about this is added to the README.

Closes #59.
