### PR TITLE
Set GNOME background image in dark mode

### DIFF
--- a/examples/hook/gsettings
+++ b/examples/hook/gsettings
@@ -6,3 +6,4 @@ hook: "S=$(xdpyinfo | grep dimensions | sed -r \"s/^[^0-9]*([0-9]+x[0-9]+).*$/\1
       "gsettings set org.gnome.desktop.background secondary-color '#073642';"
       "gsettings set org.gnome.desktop.background color-shading-type 'solid';"
       "gsettings set org.gnome.desktop.background picture-uri '$BG';"
+      "gsettings set org.gnome.desktop.background picture-uri-dark '$BG';"


### PR DESCRIPTION
Updating the GNOME example hook to set the desktop background image in dark mode too.